### PR TITLE
Miscellaneous features and fixes

### DIFF
--- a/dpkg-repack
+++ b/dpkg-repack
@@ -146,7 +146,6 @@ sub Extract_Control {
 		Die "Package $packagename not fully installed";
 	}
 	@control = grep { !/^Status:\s+/ } @control;
-	push @control, "\n";
 
 	return @control;
 }

--- a/dpkg-repack
+++ b/dpkg-repack
@@ -317,7 +317,6 @@ if (not @ARGV or not $ret) {
 	Syntax();
 	exit 1;
 }
-$build_dir = "./dpkg-repack-$$";
 
 # Some sanity checks.
 if ($> != 0) {
@@ -328,6 +327,9 @@ if (exists $ENV{FAKED_MODE} && $ENV{FAKED_MODE} ne 'unknown-is-real') {
 }
 
 foreach my $packagename (@ARGV) {
+	my $random = int(1000 + rand(9999 - 1000));
+	$build_dir = "./$packagename-$random";
+
 	my @control = Extract_Control($packagename);
 	if (!@control) {
 		Die "Unable to locate $packagename in the package list.";

--- a/dpkg-repack
+++ b/dpkg-repack
@@ -33,6 +33,7 @@ my $rootdir;
 my $arch;
 my @deb_options;
 my $generate;
+my $no_tag_description;
 
 sub Syntax {
 	print { *STDERR } <<USAGE;
@@ -42,6 +43,8 @@ Options:
       --root=<dir>      Take package from filesystem rooted on <dir>.
       --arch=<arch>     Force the parch to be built for architecture <arch>.
       --generate        Generate build directory but do not build deb.
+  --no-tag-description
+                        Do not append tagline to control file.
   -d, --deb-option=<option>
                         Pass build <option> to dpkg-deb.
   -?, --help            Show this usage information.
@@ -120,21 +123,23 @@ sub Extract_Control {
 	chomp foreach @control;
 
 	# Add something to the Description to mention dpkg-repack.
-	my $indesc = 0;
-	my $x;
-	for ($x = 0; $x < @control; $x++) {
-		if ($control[$x] =~ /^(\S+):/) {
-			last if $indesc; # end of description
-			$indesc = 1 if lc $1 eq 'description';
+	if (!$no_tag_description) {
+		my $indesc = 0;
+		my $x;
+		for ($x = 0; $x < @control; $x++) {
+			if ($control[$x] =~ /^(\S+):/) {
+				last if $indesc; # end of description
+				$indesc = 1 if lc $1 eq 'description';
+			}
 		}
-	}
-	if ($indesc) {
-		my $date = qx'date -R';
-		chomp $date;
-		chomp $control[$x - 1];
-		$control[$x - 1] .= "\n";
-		$control[$x - 1] .= " .\n";
-		$control[$x - 1] .= " (Repackaged on $date by dpkg-repack.)";
+		if ($indesc) {
+			my $date = qx'date -R';
+			chomp $date;
+			chomp $control[$x - 1];
+			$control[$x - 1] .= "\n";
+			$control[$x - 1] .= " .\n";
+			$control[$x - 1] .= " (Repackaged on $date by dpkg-repack.)";
+		}
 	}
 	
 	if ($arch) {
@@ -308,6 +313,7 @@ my $ret = GetOptions(
 	'arch|a=s', \$arch,
 	'deb-option|d=s@', \@deb_options,
 	'generate|g' , \$generate,
+	'no-tag-description', \$no_tag_description,
 	'help|?', sub { Syntax(); exit 0; },
 	'version', sub { Version(); exit 0; },
 );

--- a/dpkg-repack
+++ b/dpkg-repack
@@ -141,7 +141,7 @@ sub Extract_Control {
 			$control[$x - 1] .= " (Repackaged on $date by dpkg-repack.)";
 		}
 	}
-	
+
 	if ($arch) {
 		@control = grep { !/^Architecture:/ } @control;
 		push @control, "Architecture: $arch\n";
@@ -282,7 +282,7 @@ sub Install_Files {
 			# See the changelog for version 0.17 for an
 			# explanation of what I'm doing above with
 			# directory symlinks. I rely on the order of the
-			# filelist listing parent directories first, and 
+			# filelist listing parent directories first, and
 			# then their contents.
 			# There has to be a better way to do this!
 			my $f = '';
@@ -355,7 +355,7 @@ foreach my $packagename (@ARGV) {
 		Info "created $build_dir for $packagename";
 		next;
 	}
-	
+
 	# Let dpkg-deb do its magic.
 	SafeSystem('dpkg-deb', @deb_options, '--build', $build_dir, '.', '');
 

--- a/dpkg-repack
+++ b/dpkg-repack
@@ -345,7 +345,7 @@ foreach my $packagename (@ARGV) {
 
 	# Stop here?
 	if ($generate) {
-		Info "dpkg-repack: created $build_dir for $packagename";
+		Info "created $build_dir for $packagename";
 		next;
 	}
 	

--- a/dpkg-repack
+++ b/dpkg-repack
@@ -265,7 +265,7 @@ sub Install_Files {
 		}
 
 		if (grep { $_ eq $fn } @obsolete_conffiles) {
-			Warn "Skipping obsolete conffile $fn\n";
+			Warn "Skipping obsolete conffile $fn";
 			next;
 		}
 

--- a/dpkg-repack
+++ b/dpkg-repack
@@ -41,7 +41,7 @@ Usage: dpkg-repack [option...] packagename...
 
 Options:
       --root=<dir>      Take package from filesystem rooted on <dir>.
-      --arch=<arch>     Force the parch to be built for architecture <arch>.
+      --arch=<arch>     Force the package to be built for architecture <arch>.
       --generate        Generate build directory but do not build deb.
   --no-tag-description
                         Do not append tagline to control file.

--- a/dpkg-repack.1
+++ b/dpkg-repack.1
@@ -56,6 +56,11 @@ this temporary directory by running
 \fBfakroot \-u\fP), where \fIdir\fP is the generated directory.
 .
 .TP
+.BR \-\-no\-tag\-description
+Do not append timestamped "Repackaged by dpkg-repack" tagline to the package's
+control file description.
+.
+.TP
 .I packagename
 The name of the package to attempt to repack. Multiple packages can be listed.
 .

--- a/dpkg-repack.1
+++ b/dpkg-repack.1
@@ -3,7 +3,7 @@
 dpkg\-repack \- put an unpacked .deb file back together
 .
 .SH SYNOPSIS
-\fBdpkg\-repack\fP [\fIoption\fP...] \fIpackage-name\fP...
+\fBdpkg\-repack\fP [\fIoption\fP...] \fIpackagename\fP...
 .
 .SH DESCRIPTION
 .B dpkg\-repack
@@ -56,7 +56,7 @@ this temporary directory by running
 \fBfakroot \-u\fP), where \fIdir\fP is the generated directory.
 .
 .TP
-.I package-name
+.I packagename
 The name of the package to attempt to repack. Multiple packages can be listed.
 .
 .SH BUGS

--- a/dpkg-repack.1
+++ b/dpkg-repack.1
@@ -10,7 +10,7 @@ dpkg\-repack \- put an unpacked .deb file back together
 creates a .deb file out of a Debian package
 that has already been installed on your system.
 
-If any changes have been made to the package while it was unpacked (ie,
+If any changes have been made to the package while it was unpacked (e.g.
 conffiles files in /etc modified), the new package will inherit the
 changes. (There are exceptions to this, including changes to configuration
 files that are not conffiles, including those managed by ucf.)


### PR DESCRIPTION
Hi, I had a few changes to submit that you may or may not be interested in.

Most importantly, I noticed an issue when generating multiple build directories (e.g. `dpkg-repack --generate PROGRAM1 PROGRAM2 PROGRAM3`). It moves files for all of the programs into one build directory `./dpkg-repack-$$`, so it appears there is a need for unique build directories. I used the format `./$packagename-$random` though perhaps you'd prefer some other format.

I also noticed that control files had an extra newline appended (i.e. there appeared to be 2 blank lines at the bottom). So I removed the final array push `push @control, "\n";`. There may have been a good reason for that line (perhaps under some other circumstances?), but removing it seemed to fix the issue.

Lastly I want to make repacked archives as close to original as possible (which necessitates making the "repacked by dpkg-repack" control file Description tagline optional). I noticed this was also #788628 in the wishlist at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=788628. I added the option as `--no-tag`.
